### PR TITLE
Fixed code to work with both upper, lowercase HTTP headers

### DIFF
--- a/src/IconScraper/DataAccess.php
+++ b/src/IconScraper/DataAccess.php
@@ -17,10 +17,22 @@ class DataAccess {
     public function retrieveHeader($url) {
         $this->setContext();
 
+        // get_headers already follows redirects and stacks headers up in array
         $headers = @get_headers($url, TRUE);
+        $headers = array_change_key_case($headers);
 
-        return array_change_key_case($headers);
+        // if there were multiple redirects flatten down the location header
+        if (isset($headers['location']) && is_array($headers['location'])) {
+            $headers['location'] = array_filter($headers['location'], function ($header) {
+                return strpos($header, '://') !== false; // leave only absolute urls
+            });
+
+            $headers['location'] = end($headers['location']);
+        }
+
+        return $headers;
     }
+    
 	
     public function saveCache($file, $data) {
         file_put_contents($file, $data);

--- a/src/IconScraper/DataAccess.php
+++ b/src/IconScraper/DataAccess.php
@@ -16,7 +16,10 @@ class DataAccess {
 	
     public function retrieveHeader($url) {
         $this->setContext();
-        return @get_headers($url, TRUE);
+
+        $headers = @get_headers($url, TRUE);
+
+        return array_change_key_case($headers);
     }
 	
     public function saveCache($file, $data) {

--- a/src/IconScraper/Scraper.php
+++ b/src/IconScraper/Scraper.php
@@ -90,7 +90,7 @@ class Scraper
             switch ($status) {
                 case '301':
                 case '302':
-                    $url = $headers['Location'];
+                    $url = $headers['location'];
                     break;
                 default:
                     $loop = false;

--- a/src/IconScraper/Scraper.php
+++ b/src/IconScraper/Scraper.php
@@ -64,41 +64,32 @@ class Scraper
         return $return;
     }
 
-    public function info($url)
-    {
+   public function info($url) {
         if (empty($url) || $url === false) {
             return false;
         }
 
-        $max_loop = 5;
+        $headers = $this->dataAccess->retrieveHeader($url);
 
-        // Discover real status by following redirects. 
-        $loop = true;
-        $status = null;
-        while ($loop && $max_loop-- > 0) {
+        // leaves only numeric keys
+        $status_lines = array_filter($headers, function ($key) {
+            return is_int($key);
+        }, ARRAY_FILTER_USE_KEY);
 
-            $headers = $this->dataAccess->retrieveHeader($url);
+        // uses last returned status line header
+        $exploded = explode(' ', end($status_lines));
 
-            $exploded = explode(' ', $headers[0]);
-
-            if (!array_key_exists(1, $exploded)) {
-                return false;
-            }
-
-            list(,$status) = $exploded;
-
-            switch ($status) {
-                case '301':
-                case '302':
-                    $url = $headers['location'];
-                    break;
-                default:
-                    $loop = false;
-                    break;
-            }
+        if (! array_key_exists(1, $exploded)) {
+            return false;
         }
 
-        return array('status' => $status, 'url' => $url);
+        list(, $status) = $exploded;
+
+        if (isset($headers['location'])) {
+            $url = $headers['location'];
+        }
+
+        return ['status' => $status, 'url' => $url];
     }
 
     /**


### PR DESCRIPTION
According to RFC headers are case insensitive https://www.w3.org/Protocols/rfc2616/rfc2616.html

`Each header field consists of a name followed by a colon (":") and the field value. Field names are case-insensitive.`

This pull request fixes a hard coded use of `Location` header