### PR TITLE
Fix "icon" link detection logic

### DIFF
--- a/src/IconScraper/Scraper.php
+++ b/src/IconScraper/Scraper.php
@@ -165,7 +165,7 @@ class Scraper
                             $type = Icon::APPLE_TOUCH;
                             break;
                         default:
-                            if(strpos($link->getAttribute('href'), 'icon') !== FALSE) {
+                            if(strpos($attribute, 'icon') !== FALSE) {
                                 $type = Icon::FAVICON;
                                 $size = [];
                             }

--- a/src/IconScraper/Scraper.php
+++ b/src/IconScraper/Scraper.php
@@ -165,7 +165,7 @@ class Scraper
                             $type = Icon::APPLE_TOUCH;
                             break;
                         default:
-                            if(strpos($attribute, 'icon') !== FALSE) {
+                            if(strpos(strtolower($attribute), 'icon') !== FALSE) {
                                 $type = Icon::FAVICON;
                                 $size = [];
                             }


### PR DESCRIPTION
It should check for `rel` attribute containing "icon" text, and not its `href`.
And do it ignoring case.

Test cases that were failing before this PR:
- False negative: `<link rel="icon" href="/website.ico" />`
- False positive: `<link ref="stylesheet" href="/icons.css" />`
- False negative: `<link rel="ICON" href="/favicon.ico" />`