### PR TITLE
Fix error case of get_headers function

### DIFF
--- a/src/IconScraper/DataAccess.php
+++ b/src/IconScraper/DataAccess.php
@@ -19,6 +19,9 @@ class DataAccess {
 
         // get_headers already follows redirects and stacks headers up in array
         $headers = @get_headers($url, TRUE);
+        if ($headers === false) {
+            return array();
+        }
         $headers = array_change_key_case($headers);
 
         // if there were multiple redirects flatten down the location header


### PR DESCRIPTION
According to https://secure.php.net/manual/en/function.get-headers.php
`get_headers` returns `false` in case an error occurs. Thus, the
next function call throws a warning because it does not expect boolean input.

Ref https://github.com/nextcloud/mail/issues/647